### PR TITLE
fix: remove unnecessary errors assignment

### DIFF
--- a/src/Paynow/Exception/PaynowException.php
+++ b/src/Paynow/Exception/PaynowException.php
@@ -15,9 +15,6 @@ class PaynowException extends Exception
         if ($body) {
             $json = json_decode($body);
             if ($json->errors) {
-                foreach ($json->errors as $error) {
-                    $this->errors[] = new Error($error->errorType, $error->message);
-                }
                 $this->errors = $json->errors;
             }
         }


### PR DESCRIPTION
Setting `$this->errors[] = ...` and the reassigning it (`$this->errors = $json->errors`) doesn't make any sense