### PR TITLE
Start urls with slash

### DIFF
--- a/src/Paynow/Configuration.php
+++ b/src/Paynow/Configuration.php
@@ -4,8 +4,8 @@ namespace Paynow;
 
 class Configuration implements ConfigurationInterface
 {
-    public const API_VERSION = 'v1';
-    public const API_VERSION_V2 = 'v2';
+    public const API_VERSION = '/v1';
+    public const API_VERSION_V2 = '/v2';
     public const API_PRODUCTION_URL = 'https://api.paynow.pl';
     public const API_SANDBOX_URL = 'https://api.sandbox.paynow.pl';
     public const USER_AGENT = 'paynow-php-sdk';

--- a/src/Paynow/Service/Payment.php
+++ b/src/Paynow/Service/Payment.php
@@ -25,7 +25,7 @@ class Payment extends Service
             $decodedApiResponse = $this->getClient()
                 ->getHttpClient()
                 ->post(
-                    '/' . Configuration::API_VERSION . '/payments',
+                     Configuration::API_VERSION . '/payments',
                     $data,
                     $idempotencyKey ?? $data['externalId']
                 )

--- a/src/Paynow/Service/Refund.php
+++ b/src/Paynow/Service/Refund.php
@@ -25,7 +25,7 @@ class Refund extends Service
             $decodedApiResponse = $this->getClient()
                 ->getHttpClient()
                 ->post(
-                    '/' . Configuration::API_VERSION . '/payments/' . $paymentId . '/refunds',
+                    Configuration::API_VERSION . '/payments/' . $paymentId . '/refunds',
                     [
                         'amount' => $amount,
                         'reason' => $reason

--- a/src/Paynow/Service/ShopConfiguration.php
+++ b/src/Paynow/Service/ShopConfiguration.php
@@ -25,7 +25,7 @@ class ShopConfiguration extends Service
             return $this->getClient()
                 ->getHttpClient()
                 ->patch(
-                    '/' . Configuration::API_VERSION.'/configuration/shop/urls',
+                     Configuration::API_VERSION.'/configuration/shop/urls',
                     $data
                 );
         } catch (HttpClientException $exception) {


### PR DESCRIPTION
There were few endpoints that didn't start from the slash.

Keep one place to rule all URLs.
